### PR TITLE
Adopt devcontainer spec

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -94,7 +94,7 @@ jobs:
             ${{ steps.variables.outputs.image_name }}:latest
             ${{ steps.variables.outputs.image_ref }}
           file: src/Dockerfile.emscripten-conan.dev
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: true
           cache-from: type=local,src=${{ env.CACHE_FROM_SRC }}
           cache-to: type=local,mode=max,dest=${{ env.CACHE_TO_DEST }}
           build-args: |

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -3,8 +3,9 @@ name: build-and-push
 on:
   push:
     tags:
-      - "*.*.*"
-      - feature/*/*
+      - "**.**.**"
+      - feature/**/**
+      - experiment/**/**/**
     paths:
       - src/**
       - .github/workflows/build-and-push.yml
@@ -58,19 +59,24 @@ jobs:
           fi
 
       - name: Variables
-        if: steps.run_state.outputs.run_docker_build == 'true'
         id: variables
         run: |
           image_name=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.CONTAINER_NAME }}
           repo_tag=${{ steps.latest_tag.outputs.tag }}
           image_tag=${repo_tag//\//-}
+          dev_image_tag="${image_tag}"
           image_ref="${image_name}:${image_tag}"
           short_image_ref="${{ env.CONTAINER_NAME }}:${image_tag}"
+          dev_image_ref="$image_name:$dev_image_tag"
+          short_dev_image_ref="${{ env.CONTAINER_NAME }}:$dev_image_tag"
 
           echo "::set-output name=image_name::$image_name"
           echo "::set-output name=image_tag::$image_tag"
+          echo "::set-output name=dev_image-tag::$dev_image_tag"
           echo "::set-output name=image_ref::$image_ref"
-          echo "::set-output name=short_image_ref::$short_image_ref"
+          echo "::set-output name=short_image-ref::$short_image_ref"
+          echo "::set-output name=dev_image_ref::$dev_image_ref"
+          echo "::set-output name=short_dev_image-ref::$short_dev_image_ref"
 
       - name: Set up Docker Buildx
         if: steps.run_state.outputs.run_docker_build == 'true'
@@ -99,6 +105,19 @@ jobs:
           cache-to: type=local,mode=max,dest=${{ env.CACHE_TO_DEST }}
           build-args: |
             ROOT_PASS=${{ secrets.DOCKER_IMAGE_ROOT_PASS }}
+
+      - name: Build devcontainer ${{ steps.variables.outputs.short_dev_image_ref }}
+        if: steps.run_state.outputs.run_docker_build == 'true'
+        id: devcontainer_build
+        uses: devcontainers/ci@v0.2
+        env:
+          IMAGE_NAME: ${{ steps.variables.outputs.image_name }}
+          IMAGE_TAG: ${{ steps.variables.outputs.image_tag }}
+        with:
+          imageName: ${{ steps.variables.outputs.image_name }}
+          imageTag: ${{ steps.variables.outputs.image_tag }}
+          subFolder: src
+          runCmd: /scripts/devcontainer-check.sh
 
       - name: Set Docker Hub description
         if: steps.run_state.outputs.run_docker_build == 'true'

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -2,9 +2,6 @@ name: build-and-push
 
 on:
   push:
-    branches:
-      - main
-      - feature/*
     tags:
       - "*.*.*"
       - feature/*/*
@@ -61,6 +58,7 @@ jobs:
           fi
 
       - name: Variables
+        if: steps.run_state.outputs.run_docker_build == 'true'
         id: variables
         run: |
           image_name=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.CONTAINER_NAME }}
@@ -101,10 +99,6 @@ jobs:
           cache-to: type=local,mode=max,dest=${{ env.CACHE_TO_DEST }}
           build-args: |
             ROOT_PASS=${{ secrets.DOCKER_IMAGE_ROOT_PASS }}
-
-      - name: Image digest
-        if: steps.run_state.outputs.run_docker_build == 'true'
-        run: echo ${{ steps.docker_build.outputs.digest }}
 
       - name: Set Docker Hub description
         if: steps.run_state.outputs.run_docker_build == 'true'

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+      - feature/*
+    tags:
+      - "*.*.*"
+      - feature/*/*
     paths:
       - src/**
       - .github/workflows/build-and-push.yml
@@ -31,12 +35,22 @@ jobs:
         with:
           files: |
             src/**
+            .github/workflows/build-and-push.yml
+
+      - name: Get latest tag
+        id: latest_tag
+        uses: WyriHaximus/github-action-get-previous-tag@v1
+        with:
+          fallback: tag-unavailable
 
       - name: Declare run state
         id: run_state
         run: |
-          if [ ${{ steps.changed_files.outputs.any_modified }} == true ] || \
-            [ ${{ github.event_name }} == workflow_dispatch ];
+          if [ ${{ steps.latest_tag.outputs.tag }} != tag-unavailable ] && \
+            ( \
+              [ ${{ steps.changed_files.outputs.any_modified }} == true ] || \
+              [ ${{ github.event_name }} == workflow_dispatch ] \
+            );
           then
             echo "::set-output name=run_docker_build::true"
             echo "::debug::Docker build will carry out as expected."
@@ -45,6 +59,20 @@ jobs:
             echo "::debug::Docker build is cancelled as none of the watched files have been changed."
             echo "Docker build is cancelled as none of the watched files have been changed."
           fi
+
+      - name: Variables
+        id: variables
+        run: |
+          image_name=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.CONTAINER_NAME }}
+          repo_tag=${{ steps.latest_tag.outputs.tag }}
+          image_tag=${repo_tag//\//-}
+          image_ref="${image_name}:${image_tag}"
+          short_image_ref="${{ env.CONTAINER_NAME }}:${image_tag}"
+
+          echo "::set-output name=image_name::$image_name"
+          echo "::set-output name=image_tag::$image_tag"
+          echo "::set-output name=image_ref::$image_ref"
+          echo "::set-output name=short_image_ref::$short_image_ref"
 
       - name: Set up Docker Buildx
         if: steps.run_state.outputs.run_docker_build == 'true'
@@ -58,15 +86,15 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build image and push to Docker Hub and GitHub Container Registry
+      - name: Build image and push ${{ steps.variables.outputs.short_image_ref }}
         if: steps.run_state.outputs.run_docker_build == 'true'
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           context: .
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME}}/${{ env.CONTAINER_NAME }}:latest
-            ${{ secrets.DOCKERHUB_USERNAME}}/${{ env.CONTAINER_NAME }}:1.0.0
+            ${{ steps.variables.outputs.image_name }}:latest
+            ${{ steps.variables.outputs.image_ref }}
           file: src/Dockerfile.emscripten-conan.dev
           push: ${{ github.ref == 'refs/heads/main' }}
           cache-from: type=local,src=${{ env.CACHE_FROM_SRC }}
@@ -84,7 +112,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.CONTAINER_NAME }}
+          repository: ${{ steps.variables.outputs.image_name }}
           short-description: Emscripten + Conan devcontainers
           readme-filepath: src/DOCKER_README.md
 

--- a/src/.devcontainer/devcontainer.json
+++ b/src/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "image": "${localEnv:IMAGE_NAME}:${localEnv:IMAGE_TAG}",
+  "features": {
+    "github-cli": "latest",
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "latest"
+    }
+  }
+}

--- a/src/Dockerfile.emscripten-conan.dev
+++ b/src/Dockerfile.emscripten-conan.dev
@@ -39,3 +39,4 @@ RUN chmod +x \
   /root/.inputrc
 
 RUN echo "root:$ROOT_PASS" | chpasswd
+COPY src/scripts /scripts

--- a/src/scripts/devcontainer-check.sh
+++ b/src/scripts/devcontainer-check.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+required_packages="gh conan vim git cmake nginx curl"
+
+for exec in $required_packages;
+do
+  if [ -z "$(which $exec)" ];
+  then
+    echo "Error: $exec is not available inside the container"
+    exit 1
+  fi
+done


### PR DESCRIPTION
- Adds `devcontainer.json` for to be used by the new `devcontainer/ci`
  step to create a dev container that is compliant with the devcontainer 
  spec.
- Adds a new step to the `build-and-push` workflow for creating all the
  variables that are consumed in the following steps.
- Adds support for github cli and condespaces ssh connections through
  devcontainer spec.
- Adds a script file that is copied inside the devcontainer to check
  whether all the executables that are required for the devcontainer are 
  actually installed.
