### PR TITLE
Feat: Update devcontainer libraries and tools

### DIFF
--- a/src/Dockerfile.emscripten-conan.dev
+++ b/src/Dockerfile.emscripten-conan.dev
@@ -18,13 +18,20 @@ RUN apt-get update && \
   clang-14 \
   lsb-release \
   cmake \
-  nginx \
   curl \
-  vim \
+  wget \
   -y
 RUN ln -s /usr/bin/clang-14 /usr/local/bin/clang && \
   ln -s /usr/bin/clang++-14 /usr/local/bin/clang++
 RUN pip install conan --quiet
+
+# Neovim requires manual retrieval of the latest version
+# as the apt package is quite old
+RUN wget https://github.com/neovim/neovim/releases/download/v0.8.0/nvim-linux64.deb \
+  -O /neovim.deb
+RUN apt install -y /neovim.deb 
+RUN rm /neovim.deb
+ENV EDITOR=nvim
 
 # Gists
 ADD https://gist.githubusercontent.com/utkusarioglu/2d4be44dc7707afccd540ad99ba385e6/raw/create-env-example.sh \

--- a/src/scripts/devcontainer-check.sh
+++ b/src/scripts/devcontainer-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-required_packages="gh conan vim git cmake nginx curl"
+required_packages="gh conan nvim git cmake curl"
 
 for exec in $required_packages;
 do


### PR DESCRIPTION
- Update `.basrc` and `inputrc` files.
- Remove nginx. A simple python or node package shall be used as a
  simple webserver if the need ever arises.
- Remove vim. Instead nvim is added to the devcontainer. This is
  done because nvim also acts as a server for vscode editing functions.
- Update `devcontainer-check.sh` to check for 'nvim' instead of 'vim'.
